### PR TITLE
add ai chat bot page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import SearchMentees from './page/SearchMentees';
 import Report from './page/Report';
 import Profile from './page/Profile';
 import JobBoard from './page/JobBoard';
+import AiChat from './page/AiChat';
 import {restoreUserThunk} from './store/session';
 
 const App = () => {
@@ -46,6 +47,7 @@ const App = () => {
 					<Route path="mentee_detail" element={<MenteeDetail />} />
 					<Route path="directMessage" element={<DirectMessage />} />
 					<Route path="jobBoard" element={<JobBoard />} />
+					<Route path="aiChatBot" element={<AiChat />} />
 				</Route>
 			</Routes>
 		</>

--- a/frontend/src/page/AiChat.js
+++ b/frontend/src/page/AiChat.js
@@ -1,0 +1,69 @@
+import React, {useState, useEffect} from 'react';
+import axios from 'axios';
+
+const AiChat = () => {
+	const [messages, setMessages] = useState(
+		JSON.parse(localStorage.getItem('messages')) || []
+	);
+	const [input, setInput] = useState('');
+
+	useEffect(() => {
+		localStorage.setItem('messages', JSON.stringify(messages));
+	}, [messages]);
+
+	const getResponse = async message => {
+		try {
+			const response = await axios.post('http://localhost:8080', {
+				input: message,
+			}); // replace this with your GPT API endpoint
+			return response.data.message;
+		} catch (err) {
+			console.error(err);
+			return 'Error getting response';
+		}
+	};
+
+	const handleSubmit = async event => {
+		event.preventDefault();
+
+		setMessages([...messages, {text: input, user: 'human'}]);
+		setInput('');
+
+		const response = await getResponse(input);
+
+		setMessages(prevMessages => [
+			...prevMessages,
+			{text: response, user: 'AI'},
+		]);
+	};
+
+	const handleClear = () => {
+		localStorage.removeItem('messages');
+		setMessages([]);
+	};
+
+	return (
+		<div>
+			<h1>Chat with GPT</h1>
+			<div>
+				{messages.map((message, index) => (
+					<p key={index}>
+						<strong>{message.user}:</strong> {message.text}
+					</p>
+				))}
+			</div>
+			<form onSubmit={handleSubmit}>
+				<input
+					type="text"
+					value={input}
+					onChange={e => setInput(e.target.value)}
+					required
+				/>
+				<button type="submit">Send</button>
+			</form>
+			<button onClick={handleClear}>Clear Chat</button>
+		</div>
+	);
+};
+
+export default AiChat;

--- a/frontend/src/page/DashBoardSideBar.js
+++ b/frontend/src/page/DashBoardSideBar.js
@@ -4,14 +4,13 @@ import {Link, Outlet, useNavigate} from 'react-router-dom';
 import {Dialog, Menu, Transition} from '@headlessui/react';
 import {
 	Bars3Icon,
-	UserGroupIcon,
-	HomeIcon,
 	XMarkIcon,
 	ChatBubbleLeftIcon,
 	UserCircleIcon,
 	ChartPieIcon,
 	BriefcaseIcon,
 	UsersIcon,
+	FaceSmileIcon,
 } from '@heroicons/react/24/outline';
 import {MagnifyingGlassIcon} from '@heroicons/react/20/solid';
 import {useDispatch} from 'react-redux';
@@ -83,6 +82,12 @@ function DashBoard() {
 				icon: BriefcaseIcon,
 				current: currentTab === 'Job posts',
 			},
+			{
+				name: 'Chatbot',
+				href: 'aiChatBot',
+				icon: FaceSmileIcon,
+				current: currentTab === 'Chatbot',
+			},
 		];
 	} else {
 		navigation = [
@@ -121,6 +126,12 @@ function DashBoard() {
 				href: 'jobBoard',
 				icon: BriefcaseIcon,
 				current: currentTab === 'Job posts',
+			},
+			{
+				name: 'Chatbot',
+				href: 'aiChatBot',
+				icon: FaceSmileIcon,
+				current: currentTab === 'Chatbot',
 			},
 		];
 	}


### PR DESCRIPTION
## Summary:

This pull request implements a new chat bot interface within our application. The chat bot uses the GPT model to respond to user messages and is built using React. The chat history is persisted across sessions using `localStorage`.

## Changes Made:

- Added a new `ChatInterface` component in React.
- Implemented `getResponse` function which interacts with our GPT endpoint using axios.
- Integrated `localStorage` to persist the chat history across sessions.
- Added a "Clear Chat" button to allow users to clear the chat history.

## How to Test:

1. Navigate to the chat bot interface in the application.
2. Enter a message and submit. The chat bot should respond and the messages should be displayed on the screen.
3. Refresh the page. The previous chat history should still be visible.
4. Click on the "Clear Chat" button. The chat history should be cleared.

Please review these changes and let me know of any feedback or concerns. I'm open to further discussion and look forward to getting this feature integrated into our application.
